### PR TITLE
Adds ReactRouter and Pages 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
+#evv
+.env
+
 ##firebase 
 /.firebase
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# DB8 Calendar
+# DB8 Community
 
-DB8 Calendar is a calendar system for British Parliamentary and WSDC style debate events.
+DB8 Community is a calendar system for British Parliamentary and WSDC style debate events.
 
 ## 💡 Features
 
@@ -16,4 +16,5 @@ DB8 is released under GNU GENERAL PUBLIC LICENSE Version 3
 
 1. Clone the repo
 2. Use 'yarn install'
+4. Create and file .env at root and add the key REACT_APP_ANALYTICS_ID
 3. Use 'yarn start' to run the project. 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "react-ga": "^3.0.0",
     "react-i18next": "^11.7.0",
     "react-redux": "^7.2.0",
-    "react-scripts": "3.4.1", 
+    "react-router-dom": "^5.2.0",
+    "react-scripts": "3.4.1",
     "redux": "^4.0.5",
     "redux-saga": "^1.1.3"
   },

--- a/src/App.js
+++ b/src/App.js
@@ -1,12 +1,18 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { Layout } from "antd";
 import MainBar from "./components/molecular/MainBar";
 import EventsFeed from "./pages/EventsFeed";
 import { BrowserRouter as Router, Switch, Route } from "react-router-dom";
+import ReactGA from "react-ga";
 import "./App.less";
 
 function App() {
   const { Header, Content } = Layout;
+
+  useEffect(() => {
+    ReactGA.initialize(process.env.REACT_APP_ANALYTICS_ID);
+    ReactGA.pageview(window.location.pathname + window.location.search);
+  }, []);
 
   return (
     <Router>

--- a/src/App.js
+++ b/src/App.js
@@ -1,95 +1,32 @@
-import React, { useEffect } from 'react';
-import { Layout, List, Card, Row, Col } from 'antd';
-import { useTranslation } from 'react-i18next';
-import './App.less';
-import { useQuery } from './hooks/useQuery';
-import EventCard from './components/molecular/EventCard';
-import { listEventsRequest } from '../src/redux/actions/eventsActions';
-import { connect } from 'react-redux';
-import MainBar from './components/molecular/MainBar';
-function App(props) {
-  const { events, listEventsRequest: listEventsReq } = props;
+import React from "react";
+import { Layout } from "antd";
+import MainBar from "./components/molecular/MainBar";
+import EventsFeed from "./pages/EventsFeed";
+import { BrowserRouter as Router, Switch, Route } from "react-router-dom";
+import "./App.less";
+
+function App() {
   const { Header, Content } = Layout;
 
-  const { t } = useTranslation();
-
-  useEffect(() => {
-    listEventsReq();
-  }, [listEventsReq]);
-
   return (
-    <Layout>
-      <Header style={{ padding: '0 15px' }}>
-        <MainBar />
-      </Header>
+    <Router>
       <Layout>
-        <Content style={{ margin: 20 }}>
-          <Row>
-            <Col span={24}>
-              <Card
-                bodyStyle={{ padding: 0 }}
-                style={{ borderRadius: '22px', marginBottom: '12px', padding: 0 }}
-              >
-                <Row
-                  style={{
-                    display: 'flex',
-                    justifyContent: 'center',
-                    minHeight: '50px',
-                    alignItems: 'flex-end',
-                  }}
-                >
-                  <Col
-                    onClick={() => listEventsReq()}
-                    style={{
-                      alignItems: 'flex-end',
-                      display: 'flex',
-                      justifyContent: 'center',
-                      fontSize: '15px',
-                      fontWeight: 'bold',
-                      borderBottom: '2px solid #1890ff',
-                      height: '100%',
-                      padding: '10px',
-                    }}
-                  >
-                    {t('main-bar-explore')}
-                  </Col>
-                </Row>
-              </Card>
-            </Col>
-          </Row>
-  
-          <List
-            grid={{
-              gutter: 16,
-              xs: 1,
-              sm: 2,
-              md: 2,
-              lg: 3,
-              xl: 3,
-              xxl: 4,
-            }}
-            loading={events.isLoading}
-            dataSource={events.data}
-            renderItem={(event) => (
-              <List.Item>
-                <EventCard event={event} />
-              </List.Item>
-            )}
-          />
-        </Content>
+        <Header style={{ padding: "0 15px" }}>
+          <MainBar />
+        </Header>
+        <Layout>
+          <Content style={{ margin: 20 }}>
+            <Switch>
+              <Route path="/events/post">Agregar a un evento</Route>
+              <Route path="/">
+                <EventsFeed />
+              </Route>
+            </Switch>
+          </Content>
+        </Layout>
       </Layout>
-    </Layout>
+    </Router>
   );
 }
 
-App.prototypes = {};
-
-App.defaultProps = {};
-
-function mapStateToProps(state) {
-  return {
-    events: state.events.eventsList,
-  };
-}
-
-export default connect(mapStateToProps, { listEventsRequest })(App);
+export default App;

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,11 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import './index.css';
-import App from './App';
-import * as serviceWorker from './serviceWorker';
-import './i18n';
-import { Provider } from 'react-redux';
-import appStore from './redux/store';
+import React from "react";
+import ReactDOM from "react-dom";
+import "./index.css";
+import App from "./App";
+import * as serviceWorker from "./serviceWorker";
+import "./i18n";
+import { Provider } from "react-redux";
+import appStore from "./redux/store";
 
 ReactDOM.render(
   <React.StrictMode>
@@ -13,10 +13,11 @@ ReactDOM.render(
       <App />
     </Provider>
   </React.StrictMode>,
-  document.getElementById('root')
+  document.getElementById("root")
 );
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.
 // Learn more about service workers: https://bit.ly/CRA-PWA
+
 serviceWorker.unregister();

--- a/src/pages/EventsFeed/EventsFeed.js
+++ b/src/pages/EventsFeed/EventsFeed.js
@@ -1,0 +1,86 @@
+import React, { useEffect } from "react";
+import { Row, Card, Col, List } from "antd";
+import { connect } from "react-redux";
+import { listEventsRequest } from "../../redux/actions/eventsActions";
+import EventCard from '../../components/molecular/EventCard'
+
+import { useTranslation } from "react-i18next";
+
+function EventsFeed(props) {
+  const { listEventsRequest: listEventsReq, events } = props;
+  const { t } = useTranslation();
+
+  useEffect(() => {
+    listEventsReq();
+  }, [listEventsReq]);
+
+
+  return (
+    <>
+      <Row>
+        <Col span={24}>
+          <Card
+            bodyStyle={{ padding: 0 }}
+            style={{
+              borderRadius: "22px",
+              marginBottom: "12px",
+              padding: 0,
+            }}
+          >
+            <Row
+              style={{
+                display: "flex",
+                justifyContent: "center",
+                minHeight: "50px",
+                alignItems: "flex-end",
+              }}
+            >
+              <Col
+                onClick={() => listEventsReq()}
+                style={{
+                  alignItems: "flex-end",
+                  display: "flex",
+                  justifyContent: "center",
+                  fontSize: "15px",
+                  fontWeight: "bold",
+                  borderBottom: "2px solid #1890ff",
+                  height: "100%",
+                  padding: "10px",
+                }}
+              >
+                {t("main-bar-explore")}
+              </Col>
+            </Row>
+          </Card>
+        </Col>
+      </Row>
+
+      <List
+        grid={{
+          gutter: 16,
+          xs: 1,
+          sm: 2,
+          md: 2,
+          lg: 3,
+          xl: 3,
+          xxl: 4,
+        }}
+        loading={events.isLoading}
+        dataSource={events.data}
+        renderItem={(event) => (
+          <List.Item>
+            <EventCard event={event} />
+          </List.Item>
+        )}
+      />
+    </>
+  );
+}
+
+function mapStateToProps(state) {
+  return {
+    events: state.events.eventsList,
+  };
+}
+
+export default connect(mapStateToProps, { listEventsRequest })(EventsFeed);

--- a/src/pages/EventsFeed/index.js
+++ b/src/pages/EventsFeed/index.js
@@ -1,0 +1,2 @@
+import EventsFeed from './EventsFeed';
+export default EventsFeed

--- a/yarn.lock
+++ b/yarn.lock
@@ -1044,7 +1044,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.10.1", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.10.4", "@babel/runtime@^7.11.1", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.1", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3":
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.10.1", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.10.4", "@babel/runtime@^7.11.1", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.1", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3":
   version "7.11.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
   integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
@@ -5228,6 +5228,18 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
+history@^4.9.0:
+  version "4.10.1"
+  resolved "https://registry.yarnpkg.com/history/-/history-4.10.1.tgz#33371a65e3a83b267434e2b3f3b1b4c58aad4cf3"
+  integrity sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    loose-envify "^1.2.0"
+    resolve-pathname "^3.0.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
+    value-equal "^1.0.1"
+
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -5237,7 +5249,7 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
+hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -5946,6 +5958,11 @@ is-wsl@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.1.1.tgz#4a1c152d429df3d441669498e2486d3596ebaf1d"
   integrity sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog==
+
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
 
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -6845,7 +6862,7 @@ loglevel@^1.6.6:
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.7.tgz#b3e034233188c68b889f5b862415306f565e2c56"
   integrity sha512-cY2eLFrQSAfVPhCgH1s7JI73tMbg9YC3v3+ZHVW67sBS7UxWzNEk/ZBbSfLykBWHp33dqqtOv82gjhKEi81T/A==
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -7048,6 +7065,14 @@ min-indent@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
+
+mini-create-react-context@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/mini-create-react-context/-/mini-create-react-context-0.4.0.tgz#df60501c83151db69e28eac0ef08b4002efab040"
+  integrity sha512-b0TytUgFSbgFJGzJqXPKCFCBWigAjpjo+Fl7Vf7ZbKRDptszpppKxXH6DRXEABZ/gcEQczeb0iZ7JvL8e8jjCA==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    tiny-warning "^1.0.3"
 
 mini-css-extract-plugin@0.9.0:
   version "0.9.0"
@@ -7855,6 +7880,13 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
+
+path-to-regexp@^1.7.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
+  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
+  dependencies:
+    isarray "0.0.1"
 
 path-type@^2.0.0:
   version "2.0.0"
@@ -9328,7 +9360,7 @@ react-i18next@^11.7.0:
     "@babel/runtime" "^7.3.1"
     html-parse-stringify2 "2.0.1"
 
-react-is@^16.12.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.9.0:
+react-is@^16.12.0, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.9.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -9343,6 +9375,35 @@ react-redux@^7.2.0:
     loose-envify "^1.4.0"
     prop-types "^15.7.2"
     react-is "^16.9.0"
+
+react-router-dom@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.2.0.tgz#9e65a4d0c45e13289e66c7b17c7e175d0ea15662"
+  integrity sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    history "^4.9.0"
+    loose-envify "^1.3.1"
+    prop-types "^15.6.2"
+    react-router "5.2.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
+
+react-router@5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.2.0.tgz#424e75641ca8747fbf76e5ecca69781aa37ea293"
+  integrity sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    history "^4.9.0"
+    hoist-non-react-statics "^3.1.0"
+    loose-envify "^1.3.1"
+    mini-create-react-context "^0.4.0"
+    path-to-regexp "^1.7.0"
+    prop-types "^15.6.2"
+    react-is "^16.6.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
 
 react-scripts@3.4.1:
   version "3.4.1"
@@ -9721,6 +9782,11 @@ resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
+
+resolve-pathname@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-3.0.0.tgz#99d02224d3cf263689becbb393bc560313025dcd"
+  integrity sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==
 
 resolve-url-loader@3.1.1:
   version "3.1.1"
@@ -10772,6 +10838,16 @@ timsort@^0.3.0:
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
 
+tiny-invariant@^1.0.2:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.1.0.tgz#634c5f8efdc27714b7f386c35e6760991d230875"
+  integrity sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==
+
+tiny-warning@^1.0.0, tiny-warning@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
+  integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
+
 tinycolor2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/tinycolor2/-/tinycolor2-1.4.1.tgz#f4fad333447bc0b07d4dc8e9209d8f39a8ac77e8"
@@ -11140,6 +11216,11 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+value-equal@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-1.0.1.tgz#1e0b794c734c5c0cade179c437d356d931a34d6c"
+  integrity sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==
 
 vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
## Abstract 
Adds basic routing structure for the front

## Purpose
Adding multiple pages to the page such an event detail and an event post 

## Summary 
- Adds 'react-router' to dependencies 
- Refactors App to add the routing structure
- Creates page Events feed 
- Connects to Google Analytics

## How to test
- Create a file at the root of the project with the name .env. This file will be ignored
-Add the following value and save
`REACT_APP_ANALYTICS_ID= EXAMPLEUA121212`
- Run `yarn start`
- Navigate to /events/post
- you should see a different page
- navigate to /any or /test
- you should see the events feed 


## A image tells more than 1000 words: 
![image](https://user-images.githubusercontent.com/43116659/90303253-2238b080-de72-11ea-9653-3c360f3f6268.png)
![image](https://user-images.githubusercontent.com/43116659/90303260-2cf34580-de72-11ea-9356-2a84fcd0b436.png)

